### PR TITLE
Use modern Twilio Messaging endpoint

### DIFF
--- a/smack-my-bitch-up.sh
+++ b/smack-my-bitch-up.sh
@@ -29,7 +29,7 @@ MESSAGE="Late at work. "$RANDOM_REASON
 # Send a text message
 RESPONSE=`curl -fSs -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" \
   -d "From=$MY_NUMBER" -d "To=$HER_NUMBER" -d "Body=$MESSAGE" \
-  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/SMS/Messages"`
+  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages"`
 
 # Log errors
 if [ $? -gt 0 ]; then


### PR DESCRIPTION
The `/SMS/Messages` endpoint is the old SMS-only endpoint. `/Messages` can send SMS and MMS, but `/SMS` will be deprecated at some point in the (probably far) future. This makes the script more future-proof.