### PR TITLE
no need to load .env file for this specific script

### DIFF
--- a/php/fucking_coffee.php
+++ b/php/fucking_coffee.php
@@ -3,9 +3,6 @@
 
 require 'vendor/autoload.php';
 
-$dotenv = new Dotenv\Dotenv(__DIR__);
-$dotenv->load();
-
 use Bestnetwork\Telnet\TelnetClient;
 
 (strpos(exec('who'), getenv('USER')) !== false) or exit('no session');


### PR DESCRIPTION
of course no need for it!
USER already exist by default in environment
.env file only used to store gmail and twilio credentials

I'll port other scripts this week