### PR TITLE
python: Add 17 second delay and set 64 second delay to 24 seconds in fucking_coffee

### DIFF
--- a/python/fucking_coffee.py
+++ b/python/fucking_coffee.py
@@ -14,13 +14,15 @@ coffee_machine_ip = '10.10.42.42'
 password = '1234'
 password_prompt = 'Password: '
 
+time.sleep(17)
+
 con = telnetlib.Telnet(coffee_machine_ip)
 con.read_until(password_prompt)
 con.write(password + "\n")
 
 # Make some coffee!
 con.write("sys brew\n")
-time.sleep(64)
+time.sleep(24)
 
 # love the smell!
 con.write("sys pour\n")

--- a/python3/fucking_coffee.py
+++ b/python3/fucking_coffee.py
@@ -24,7 +24,7 @@ def main():
     conn.write(COFFEE_MACHINE_PASS)
 
     conn.write('sys brew')
-    time.sleep(64)
+    time.sleep(24)
 
     conn.write('sys pour')
     conn.close()


### PR DESCRIPTION
First of all, the 17 second delay is missing from the Python version of fucking_coffee.

Second, the 24 second delay is set as 64 seconds in both the Python 2 and Python 3 versions.

This commit alleviates both issues.