### PR TITLE
Fixed Delay Typo's in fucking_coffee.py

### DIFF
--- a/python/fucking_coffee.py
+++ b/python/fucking_coffee.py
@@ -22,7 +22,7 @@ con.write(password + "\n")
 
 # Make some coffee!
 con.write("sys brew\n")
-time.sleep(64)
+time.sleep(24)
 
 # love the smell!
 con.write("sys pour\n")

--- a/python3/fucking_coffee.py
+++ b/python3/fucking_coffee.py
@@ -24,7 +24,7 @@ def main():
     conn.write(COFFEE_MACHINE_PASS)
 
     conn.write('sys brew')
-    time.sleep(64)
+    time.sleep(24)
 
     conn.write('sys pour')
     conn.close()


### PR DESCRIPTION
The delay in both `python` and `python3` implementation of `fucking_coffee` contains a typo.
Both delays are equal to 64 while the `README.md` describes it to be 24.