### PR TITLE
Changed milliseconds to seconds in PowerShell script

### DIFF
--- a/powershell/fucking_coffee.psm1
+++ b/powershell/fucking_coffee.psm1
@@ -58,5 +58,5 @@ Function Send-TelNetCommands
 
     $writer.WriteLine($command)
     $writer.Flush()
-    Start-Sleep -Milliseconds $WaitTime
+    Start-Sleep -s $WaitTime
 }


### PR DESCRIPTION
I'm pretty sure it is supposed to be seconds instead of milliseconds. Otherwise I want a coffee machine that can brew and pour that fast.